### PR TITLE
feat(hooks): add PPID capture for terminal tracking

### DIFF
--- a/hooks/bash.bash
+++ b/hooks/bash.bash
@@ -40,7 +40,7 @@ preexec_invoke_cmd() {
         return
     fi
 
-    shelltime track -s=bash -id=$SESSION_ID -cmd="$CMD" -p=pre &> /dev/null
+    shelltime track -s=bash -id=$SESSION_ID -cmd="$CMD" -p=pre --ppid=$PPID &> /dev/null
 }
 
 # Function to be executed after each command (before prompt)
@@ -57,13 +57,13 @@ precmd_invoke_cmd() {
     if [[ "$CMD" =~ ^shelltime ]]; then
         return
     fi
-    
+
     # Ensure CMD is not empty or the precmd_invoke_cmd itself
     if [ -z "$CMD" ] || [ "$CMD" == "precmd_invoke_cmd" ]; then
         return
     fi
 
-    shelltime track -s=bash -id=$SESSION_ID -cmd="$CMD" -p=post -r=$LAST_RESULT &> /dev/null
+    shelltime track -s=bash -id=$SESSION_ID -cmd="$CMD" -p=post -r=$LAST_RESULT --ppid=$PPID &> /dev/null
 }
 
 # Set the functions for bash-preexec

--- a/hooks/fish.fish
+++ b/hooks/fish.fish
@@ -10,13 +10,16 @@ end
 # Create a timestamp for the session when the shell starts
 set -g SESSION_ID (date +%Y%m%d%H%M%S)
 
+# Capture parent process ID at shell startup (fish doesn't have native $PPID)
+set -g FISH_PPID (ps -o ppid= -p %self | string trim)
+
 # Define the preexec function
 function fish_preexec --on-event fish_preexec
     if string match -q 'exit*' -- $argv; or string match -q 'logout*' -- $argv; or string match -q 'reboot*' -- $argv
         return
     end
 
-    shelltime track -s=fish -id=$SESSION_ID -cmd="$argv" -p=pre > /dev/null
+    shelltime track -s=fish -id=$SESSION_ID -cmd="$argv" -p=pre --ppid=$FISH_PPID > /dev/null
 end
 
 # Define the postexec function
@@ -26,5 +29,5 @@ function fish_postexec --on-event fish_postexec
         return
     end
     # This event is triggered before each prompt, which is after each command
-    shelltime track -s=fish -id=$SESSION_ID -cmd="$argv" -p=post -r=$LAST_RESULT > /dev/null
+    shelltime track -s=fish -id=$SESSION_ID -cmd="$argv" -p=post -r=$LAST_RESULT --ppid=$FISH_PPID > /dev/null
 end

--- a/hooks/zsh.zsh
+++ b/hooks/zsh.zsh
@@ -19,7 +19,7 @@ preexec() {
         return
     fi
 
-    shelltime track -s=zsh -id=$SESSION_ID -cmd=$CMD -p=pre --ppid=$PPID &> /dev/null
+    shelltime track -s=zsh -id=$SESSION_ID -cmd="$CMD" -p=pre --ppid=$PPID &> /dev/null
 }
 
 # Define the postexec function (in zsh, it's called precmd)
@@ -30,5 +30,5 @@ precmd() {
     if [[ $CMD =~ ^(exit|logout|reboot) ]]; then
         return
     fi
-    shelltime track -s=zsh -id=$SESSION_ID -cmd=$CMD -p=post -r=$LAST_RESULT --ppid=$PPID &> /dev/null
+    shelltime track -s=zsh -id=$SESSION_ID -cmd="$CMD" -p=post -r=$LAST_RESULT --ppid=$PPID &> /dev/null
 }

--- a/hooks/zsh.zsh
+++ b/hooks/zsh.zsh
@@ -19,7 +19,7 @@ preexec() {
         return
     fi
 
-    shelltime track -s=zsh -id=$SESSION_ID -cmd=$CMD -p=pre &> /dev/null
+    shelltime track -s=zsh -id=$SESSION_ID -cmd=$CMD -p=pre --ppid=$PPID &> /dev/null
 }
 
 # Define the postexec function (in zsh, it's called precmd)
@@ -30,5 +30,5 @@ precmd() {
     if [[ $CMD =~ ^(exit|logout|reboot) ]]; then
         return
     fi
-    shelltime track -s=zsh -id=$SESSION_ID -cmd=$CMD -p=post -r=$LAST_RESULT &> /dev/null
+    shelltime track -s=zsh -id=$SESSION_ID -cmd=$CMD -p=post -r=$LAST_RESULT --ppid=$PPID &> /dev/null
 }


### PR DESCRIPTION
## Summary

- Pass parent process ID (PPID) to shelltime track command for terminal emulator detection

## Changes

- **bash.bash**: Add `--ppid=$PPID` to track calls
- **zsh.zsh**: Add `--ppid=$PPID` to track calls
- **fish.fish**: Capture PPID at shell startup (`ps -o ppid= -p %self`), add `--ppid=$FISH_PPID` to track calls

## Related PRs

- CLI: https://github.com/shelltime/cli/pull/200
- Server: (pending)

## Notes

- Bash and Zsh have native `$PPID` variable
- Fish requires `ps` command to get parent PID at shell startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)