### PR TITLE
feat(install): prefer Homebrew installation on macOS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,5 +60,9 @@ jobs:
           fi
           [ -f ~/.shelltime/hooks/bash-preexec.sh ] || (echo "bash-preexec.sh not found in ~/.shelltime/hooks!" && exit 1)
           ls ~/.shelltime
-          ls ~/.shelltime/bin
+          if command -v brew >/dev/null 2>&1 && brew list shelltime >/dev/null 2>&1; then
+            which shelltime || (echo "shelltime not in PATH via Homebrew!" && exit 1)
+          else
+            ls ~/.shelltime/bin
+          fi
           ls ~/.shelltime/hooks

--- a/install.bash
+++ b/install.bash
@@ -24,6 +24,15 @@ if [[ "$OS" == "Darwin" ]] && command_exists brew; then
     if brew install shelltime/tap/shelltime; then
         BREW_INSTALLED=true
         echo "Successfully installed shelltime via Homebrew."
+        # Rename old manual-install binaries so the system uses the Homebrew version
+        if [ -f "$HOME/.shelltime/bin/shelltime" ]; then
+            mv "$HOME/.shelltime/bin/shelltime" "$HOME/.shelltime/bin/shelltime.bak"
+            echo "Renamed ~/.shelltime/bin/shelltime to shelltime.bak (now using Homebrew version)"
+        fi
+        if [ -f "$HOME/.shelltime/bin/shelltime-daemon" ]; then
+            mv "$HOME/.shelltime/bin/shelltime-daemon" "$HOME/.shelltime/bin/shelltime-daemon.bak"
+            echo "Renamed ~/.shelltime/bin/shelltime-daemon to shelltime-daemon.bak (now using Homebrew version)"
+        fi
     else
         echo "Homebrew installation failed. Falling back to manual installation..."
     fi

--- a/install.bash
+++ b/install.bash
@@ -9,11 +9,27 @@ command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
+# Flag to track whether Homebrew installation was used
+BREW_INSTALLED=false
+
 # Check for required commands
 if ! command_exists curl; then
     echo "Error: curl is not installed."
     exit 1
 fi
+
+# On macOS, prefer Homebrew installation if brew is available
+if [[ "$OS" == "Darwin" ]] && command_exists brew; then
+    echo "Homebrew detected on macOS. Attempting to install via brew..."
+    if brew install shelltime/tap/shelltime; then
+        BREW_INSTALLED=true
+        echo "Successfully installed shelltime via Homebrew."
+    else
+        echo "Homebrew installation failed. Falling back to manual installation..."
+    fi
+fi
+
+if [ "$BREW_INSTALLED" = false ]; then
 
 CLI_FILE_NAME="https://github.com/malamtime/cli/releases/latest/download/cli_"
 DAEMON_FILE_NAME="${CLI_FILE_NAME}daemon_"
@@ -127,14 +143,6 @@ if [[ "$OS" == "Darwin" ]] || [[ "$OS" == "Linux" ]]; then
     # mv shelltime /c/Windows/System32/
 fi
 
-# Check if $HOME/.shelltime/daemon exists, create if not
-if [ ! -d "$HOME/.shelltime/daemon" ]; then
-    mkdir -p "$HOME/.shelltime/daemon"
-    if [ $? -ne 0 ]; then
-        echo "Warning: Failed to create $HOME/.shelltime/daemon directory. Daemon functionality may be unavailable."
-    fi
-fi
-
 # Add $HOME/.shelltime/bin to user path
 if [[ "$OS" == "Darwin" ]] || [[ "$OS" == "Linux" ]]; then
     # For Zsh
@@ -185,6 +193,15 @@ if [[ "$OS" == "MINGW64_NT" ]] || [[ "$OS" == "MSYS_NT" ]] || [[ "$OS" == "CYGWI
 	echo "If you know where binaries should be installed on Windows, please open an issue: https://github.com/shelltime/cli"
 fi
 
+fi  # end of manual installation block
+
+# Check if $HOME/.shelltime/daemon exists, create if not
+if [ ! -d "$HOME/.shelltime/daemon" ]; then
+    mkdir -p "$HOME/.shelltime/daemon"
+    if [ $? -ne 0 ]; then
+        echo "Warning: Failed to create $HOME/.shelltime/daemon directory. Daemon functionality may be unavailable."
+    fi
+fi
 
 # STEP 2
 # insert a preexec and postexec script to user configuration, including `zsh` and `fish`


### PR DESCRIPTION
## Summary
- On macOS with Homebrew available, prefer `brew install shelltime/tap/shelltime` over manual binary download
- Falls back to manual installation if Homebrew install fails
- Renames existing `~/.shelltime/bin` binaries to `.bak` when migrating from manual to Homebrew, so the shell resolves to the Homebrew-managed version
- Updated CI verification to handle both Homebrew and manual install paths

## Test plan
- [ ] Run `bash ./install.bash` on macOS with Homebrew — installs via brew, sets up hooks, prints completion message
- [ ] Run `bash ./install.bash` on macOS with Homebrew + existing manual install — old binaries renamed to `.bak`
- [ ] Run `bash ./install.bash` on Linux — uses manual download path (unchanged behavior)
- [ ] Verify CI passes on both `ubuntu-latest` and `macos-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/installation/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
