### PR TITLE
feat(install): rename old manual binaries to .bak after Homebrew install

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -24,6 +24,15 @@ if [[ "$OS" == "Darwin" ]] && command_exists brew; then
     if brew install shelltime/tap/shelltime; then
         BREW_INSTALLED=true
         echo "Successfully installed shelltime via Homebrew."
+        # Rename old manual-install binaries so the system uses the Homebrew version
+        if [ -f "$HOME/.shelltime/bin/shelltime" ]; then
+            mv "$HOME/.shelltime/bin/shelltime" "$HOME/.shelltime/bin/shelltime.bak"
+            echo "Renamed ~/.shelltime/bin/shelltime to shelltime.bak (now using Homebrew version)"
+        fi
+        if [ -f "$HOME/.shelltime/bin/shelltime-daemon" ]; then
+            mv "$HOME/.shelltime/bin/shelltime-daemon" "$HOME/.shelltime/bin/shelltime-daemon.bak"
+            echo "Renamed ~/.shelltime/bin/shelltime-daemon to shelltime-daemon.bak (now using Homebrew version)"
+        fi
     else
         echo "Homebrew installation failed. Falling back to manual installation..."
     fi


### PR DESCRIPTION
When migrating from manual install to Homebrew, rename existing ~/.shelltime/bin/shelltime and shelltime-daemon with .bak suffix so the shell resolves to the Homebrew-managed version instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/installation/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
