### PR TITLE
Update GitHub organization from malamtime to shelltime

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -40,7 +40,7 @@ fi
 
 if [ "$BREW_INSTALLED" = false ]; then
 
-CLI_FILE_NAME="https://github.com/malamtime/cli/releases/latest/download/cli_"
+CLI_FILE_NAME="https://github.com/shelltime/cli/releases/latest/download/cli_"
 DAEMON_FILE_NAME="${CLI_FILE_NAME}daemon_"
 
 cd /tmp
@@ -143,10 +143,7 @@ fi
 if [[ "$OS" == "Darwin" ]] || [[ "$OS" == "Linux" ]]; then
     mv shelltime "$HOME/.shelltime/bin/"
     if [ -f "shelltime-daemon" ]; then
-        if [ -f "$HOME/.shelltime/bin/shelltime-daemon.bak" ]; then
-            rm "$HOME/.shelltime/bin/shelltime-daemon.bak"
-        fi
-        mv shelltime-daemon "$HOME/.shelltime/bin/shelltime-daemon.bak"
+        mv shelltime-daemon "$HOME/.shelltime/bin/"
     fi
 # elif [[ "$OS" == "MINGW64_NT" ]] || [[ "$OS" == "MSYS_NT" ]] || [[ "$OS" == "CYGWIN_NT" ]]; then
     # mv shelltime /c/Windows/System32/
@@ -268,14 +265,14 @@ check_and_delete_bak "zsh.zsh"
 check_and_delete_bak "fish.fish"
 
 # Process zsh.zsh
-process_file "zsh.zsh" "https://raw.githubusercontent.com/malamtime/installation/master/hooks/zsh.zsh"
+process_file "zsh.zsh" "https://raw.githubusercontent.com/shelltime/installation/master/hooks/zsh.zsh"
 
 # Process fish.fish
-process_file "fish.fish" "https://raw.githubusercontent.com/malamtime/installation/master/hooks/fish.fish"
+process_file "fish.fish" "https://raw.githubusercontent.com/shelltime/installation/master/hooks/fish.fish"
 
 # Process bash.bash
 process_file "bash-preexec.sh" "https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh"
-process_file "bash.bash" "https://raw.githubusercontent.com/malamtime/installation/master/hooks/bash.bash"
+process_file "bash.bash" "https://raw.githubusercontent.com/shelltime/installation/master/hooks/bash.bash"
 
 # Add source lines to config files
 if [ -f "$HOME/.zshrc" ]; then


### PR DESCRIPTION
## Summary
This PR updates all GitHub repository references from the `malamtime` organization to the `shelltime` organization, and simplifies the daemon installation process by removing unnecessary backup file handling.

## Key Changes
- Updated CLI release download URL from `malamtime/cli` to `shelltime/cli`
- Updated installation hook URLs from `malamtime/installation` to `shelltime/installation` (zsh, fish, and bash hooks)
- Simplified daemon installation by removing the backup file creation logic:
  - Removed check for existing `shelltime-daemon.bak` file
  - Removed deletion of backup file
  - Changed daemon installation to use standard naming (`shelltime-daemon`) instead of `.bak` suffix

## Implementation Details
The daemon installation change moves from a backup-based approach to direct installation, which simplifies the installation process and reduces unnecessary file operations. All GitHub organization references have been consistently updated across the script to reflect the new organization name.

https://claude.ai/code/session_018m32E29p45D57CCVBs6wk8
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/installation/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
