### PR TITLE
fix(install): warn when shelltime-daemon is missing from archive

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -144,6 +144,12 @@ if [[ "$OS" == "Darwin" ]] || [[ "$OS" == "Linux" ]]; then
     mv shelltime "$HOME/.shelltime/bin/"
     if [ -f "shelltime-daemon" ]; then
         mv shelltime-daemon "$HOME/.shelltime/bin/"
+    else
+        echo "" >&2
+        echo "WARNING: shelltime-daemon binary was NOT found in $FILENAME." >&2
+        echo "         The CLI will attempt to auto-download it on first" >&2
+        echo "         'shelltime daemon install/reinstall'." >&2
+        echo "" >&2
     fi
 # elif [[ "$OS" == "MINGW64_NT" ]] || [[ "$OS" == "MSYS_NT" ]] || [[ "$OS" == "CYGWIN_NT" ]]; then
     # mv shelltime /c/Windows/System32/


### PR DESCRIPTION
## Summary

Previously the script silently skipped the daemon move when `shelltime-daemon` was absent from the extracted tarball, leaving Linux users without a working daemon and no signal that anything went wrong. This made bugs like the pre-`36a09e9` `.bak` rename hard to spot in the wild.

Now print a clear stderr warning when the daemon binary is missing, pointing out that the CLI will attempt to auto-download it on first `shelltime daemon install/reinstall`.

Kept non-fatal because:
1. Paired CLI change adds `EnsureDaemonBinary` which self-heals on next `shelltime daemon install`.
2. We still want the rest of the install (hooks, PATH setup, daemon dir) to complete so `shelltime` itself works.

## Test plan

- [x] `bash -n install.bash` — syntax OK
- [ ] Manual: download a release tarball, delete `shelltime-daemon` from the extract, run the script, confirm the WARNING block appears on stderr and the rest of installation completes
- [ ] Existing CI workflow exercises the happy path on Ubuntu and macOS across zsh/bash/fish

https://claude.ai/code/session_01ThKSJA9sGXQm8jMeCZZdYY

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThKSJA9sGXQm8jMeCZZdYY)_